### PR TITLE
feat: Adapts to the MacOS platform.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Key-Echo is an Emacs plugin that uses XRecord technology to listen to system key
 
 ## Installation
 1. Install Emacs 28 or above
-2. Install Python dependencies: epc, sexpdata, six, pynput: `pip3 install epc sexpdata six pynput`
+2. Install Python dependencies: epc, sexpdata, six, pynput, pyobjc (for macos): `pip3 install epc sexpdata six pynput`
 3. Download this repository with `git clone` and replace the load-path path in the configuration below
 4. Add the following code to your configuration file ~/.emacs:
 

--- a/key-echo.el
+++ b/key-echo.el
@@ -262,7 +262,11 @@ Then Key-Echo will start by gdb, please send new issue with `*key-echo*' buffer 
       )))
 
 (defun key-echo--get-emacs-xid ()
-  (string-to-number (frame-parameter nil 'outer-window-id)))
+  (pcase system-type
+    ;; When system type is darwin, outer-window-id is always nil
+    ;; So replaced by emacs-pid
+    (darwin (emacs-pid))
+    (t (string-to-number (frame-parameter nil 'outer-window-id)))))
 
 (defun key-echo-single-key-trigger (key)
   (when key-echo-single-key-trigger-func

--- a/key_echo.py
+++ b/key_echo.py
@@ -22,9 +22,8 @@ import queue
 import threading
 import traceback
 import sys
+import platform
 import time
-from Xlib import X
-from Xlib.display import Display
 from pynput.keyboard import Listener as kbListener
 from epc.server import ThreadingEPCServer
 from utils import *
@@ -57,11 +56,11 @@ class KeyEcho:
         self.event_loop = threading.Thread(target=self.event_dispatcher)
         self.event_loop.start()
 
-        # Init xlib vars.
         self.emacs_xid = None
-        self.disp = Display()
-        self.root = self.disp.screen().root
-        self.NET_ACTIVE_WINDOW = self.disp.intern_atom('_NET_ACTIVE_WINDOW')
+        
+        if not self.isDarwin():
+            # When system type is not darwin, init xlib vars.
+            self.initXlib()
 
         # Init key event vars.
         self.last_press_key = None
@@ -78,6 +77,16 @@ class KeyEcho:
         # event_loop never exit, simulation event loop.
         self.event_loop.join()
 
+    def initXlib(self):
+        from Xlib import X
+        from Xlib.display import Display
+        self.disp = Display()
+        self.root = self.disp.screen().root
+        self.NET_ACTIVE_WINDOW = self.disp.intern_atom('_NET_ACTIVE_WINDOW')        
+
+    def isDarwin(self):
+        return platform.system().lower() == "darwin"
+
     def listen_key_event(self):
         while True:
             with kbListener(
@@ -89,6 +98,7 @@ class KeyEcho:
         return time.time() * 1000
 
     def key_press(self, key):
+        print(self.get_emacs_xid())
         if self.get_active_window_id() == self.get_emacs_xid():
             self.last_press_key = key
 
@@ -107,7 +117,14 @@ class KeyEcho:
 
         return self.emacs_xid
 
+    def get_active_window_id_osx(self):
+        from AppKit import NSWorkspace
+        return NSWorkspace.sharedWorkspace().activeApplication()['NSApplicationProcessIdentifier']            
     def get_active_window_id(self):
+        if self.isDarwin():
+            # When system type is Darwin, return MacOS pid of active application
+            return self.get_active_window_id_osx()
+        
         response = self.root.get_full_property(self.NET_ACTIVE_WINDOW,
                                       X.AnyPropertyType)
         win_id = response.value[0]


### PR DESCRIPTION
Adapts to the MacOS platform:

1. use emacs-pid to replace outer-window-id in MacOS.
2. use pyobjc to get pid of active application in MacOS.