### PR TITLE
feat: Adapts to the MacOS platform.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Key-Echo is an Emacs plugin that uses XRecord technology to listen to system key
 
 ## Installation
 1. Install Emacs 28 or above
-2. Install Python dependencies: epc, sexpdata, six, pynput: `pip3 install epc sexpdata six pynput`
+2. Install Python dependencies: epc, sexpdata, six, pynput, pyobjc (for macos): `pip3 install epc sexpdata six pynput`
 3. Download this repository with `git clone` and replace the load-path path in the configuration below
 4. Add the following code to your configuration file ~/.emacs:
 
@@ -27,4 +27,4 @@ Key-Echo is an Emacs plugin that uses XRecord technology to listen to system key
 After adding the above settings, you can freely switch the input method by pressing Shift.
 
 ## Remarks
-Currently only supports Linux, theoretically it can support Windows and macOS, contributions are welcome.
+Currently supports Linux and macOS, theoretically it can support Windows, contributions are welcome.

--- a/key-echo.el
+++ b/key-echo.el
@@ -262,7 +262,11 @@ Then Key-Echo will start by gdb, please send new issue with `*key-echo*' buffer 
       )))
 
 (defun key-echo--get-emacs-xid ()
-  (string-to-number (frame-parameter nil 'outer-window-id)))
+  (pcase system-type
+    ;; When system type is darwin, outer-window-id is always nil
+    ;; So replaced by emacs-pid
+    (darwin (emacs-pid))
+    (t (string-to-number (frame-parameter nil 'outer-window-id)))))
 
 (defun key-echo-single-key-trigger (key)
   (when key-echo-single-key-trigger-func


### PR DESCRIPTION
Adapts to the MacOS platform:

pynput.keyboard 是平台通用的，kbListener 在 Mac 下也可以获取到当前按键。

只有判断当前 active 的应用是不是 Emacs 需要单独处理。

use emacs-pid to replace outer-window-id in MacOS.
use pyobjc to get pid of active application in MacOS.